### PR TITLE
Fix bug where decoding exceptions cause previous email contents to be reused

### DIFF
--- a/mbox_process.py
+++ b/mbox_process.py
@@ -98,9 +98,16 @@ SUBJECT: {message['subject']}</br>
             # print(f"Msg: {idx +1}")
             # print(content_type)
             # print(content_disposition)
+            payload = part.get_payload(decode=True)
+            # https://docs.python.org/3/library/email.compat32-message.html#email.message.Message.get_payload
+            # "If the message is a multipart and the decode flag is True, then None is returned."
+            if payload is None:
+                # Skip this part because payload.decode() will fail otherwise
+                # print(f"Skipping None multipart payload")
+                continue
             try:
                 # get the email body
-                body = part.get_payload(decode=True).decode()
+                body = payload.decode()
             except Exception as e:
                 # set body otherwise it will have the last value during an exception
                 # TODO: Handle exceptions from get_payload and decode the data

--- a/mbox_process.py
+++ b/mbox_process.py
@@ -52,7 +52,6 @@ email_list = []
 for idx, message in enumerate(mailbox.mbox(file_name)):
     # create a folder for the message
     folder_name = f"{dir_name}/msg-{idx + 1}"
-    prev_folder = f"{dir_name}/msg-{idx}"
     if not os.path.isdir(folder_name):
         # make a folder for this email (named after the subject)
         os.mkdir(folder_name)
@@ -102,8 +101,11 @@ SUBJECT: {message['subject']}</br>
             try:
                 # get the email body
                 body = part.get_payload(decode=True).decode()
-            except:
-                pass
+            except Exception as e:
+                # set body otherwise it will have the last value during an exception
+                # TODO: Handle exceptions from get_payload and decode the data
+                body = str(e)
+                print(f"Exception in {idx + 1}: {body}")
 
             # save plain text of email
             if content_type == "text/plain":
@@ -135,15 +137,14 @@ SUBJECT: {message['subject']}</br>
                 open(filepath, "a+").write(full_message_html)
 
             # multipart/mixed messages
-            # BUG writes to wrong folder and wrong file name (+1)
             elif content_type == "multipart/mixed":
                 # add the body of the message
                 full_message_mixed = full_message + f"CONTENT: \n{body}"
 
                 # write the message to a file
                 # name the file
-                filename = f"msg-{idx}-mxd.html"
-                filepath = os.path.join(prev_folder, filename)
+                filename = f"msg-{idx + 1}-mxd.html"
+                filepath = os.path.join(folder_name, filename)
                 # write the file
                 open(filepath, "w").write(full_message_mixed)
 


### PR DESCRIPTION
I was trying to use this code to process some old mbox files and found the source of the bug that was flagged in the code. If an exception occurs during the decoding then it will use the body from the previous email. I also added support for extracting the encoding type and use that, otherwise you also get exceptions for many emails which are not UTF-8.

Thanks for writing this code, really appreciate you sharing this code since there isn't much else out there for extracting mbox files.